### PR TITLE
Restringe visualização de clientes por usuário

### DIFF
--- a/src/api/clientes/cliente.controller.js
+++ b/src/api/clientes/cliente.controller.js
@@ -42,8 +42,24 @@ const deleteCliente = async (req, res) => {
   } catch (error) { res.status(403).json({ message: error.message }); }
 };
 
-// <--- REMOVIDA: A função antiga que recebia o arquivo CSV foi substituída.
-// const uploadClientesCSV = async (req, res) => { ... };
+// Função para importar clientes a partir de um arquivo CSV.
+// Utiliza o serviço importFromCSV para garantir que cada cliente importado
+// seja associado ao usuário autenticado (req.user).
+const uploadClientesCSV = async (req, res) => {
+  try {
+    if (!req.file || !req.file.buffer) {
+      return res.status(400).json({ message: 'Arquivo CSV é obrigatório.' });
+    }
+
+    const result = await clienteService.importFromCSV(req.file.buffer, req.user);
+    res.status(201).json({
+      message: `${result.insertedCount} clientes foram importados com sucesso!`,
+      result,
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Falha ao importar clientes.', error: error.message });
+  }
+};
 
 const deleteAllClientes = async (req, res) => {
   try {
@@ -87,13 +103,13 @@ const bulkImportClientes = async (req, res) => {
 };
 
 
-module.exports = { 
+module.exports = {
   createCliente,       // Para o cadastro manual
-  getAllClientes, 
-  getClienteById, 
-  updateCliente, 
-  deleteCliente, 
-  // uploadClientesCSV, // <--- REMOVIDO dos exports
+  getAllClientes,
+  getClienteById,
+  updateCliente,
+  deleteCliente,
+  uploadClientesCSV,
   deleteAllClientes,
   bulkImportClientes   // <--- ADICIONADO: Para a importação em massa
 };


### PR DESCRIPTION
## Summary
- assegura que importações CSV associem clientes ao usuário autenticado
- adiciona teste garantindo que cada usuário veja apenas seus clientes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac856dc66c8330a237f45678166061