### PR TITLE
Restringe visualização de clientes por usuário

### DIFF
--- a/src/api/clientes/cliente.controller.js
+++ b/src/api/clientes/cliente.controller.js
@@ -42,8 +42,24 @@ const deleteCliente = async (req, res) => {
   } catch (error) { res.status(403).json({ message: error.message }); }
 };
 
-// <--- REMOVIDA: A função antiga que recebia o arquivo CSV foi substituída.
-// const uploadClientesCSV = async (req, res) => { ... };
+// Função para importar clientes a partir de um arquivo CSV.
+// Utiliza o serviço importFromCSV para garantir que cada cliente importado
+// seja associado ao usuário autenticado (req.user).
+const uploadClientesCSV = async (req, res) => {
+  try {
+    if (!req.file || !req.file.buffer) {
+      return res.status(400).json({ message: 'Arquivo CSV é obrigatório.' });
+    }
+
+    const result = await clienteService.importFromCSV(req.file.buffer, req.user);
+    res.status(201).json({
+      message: `${result.insertedCount} clientes foram importados com sucesso!`,
+      result,
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Falha ao importar clientes.', error: error.message });
+  }
+};
 
 const deleteAllClientes = async (req, res) => {
   try {
@@ -87,13 +103,13 @@ const bulkImportClientes = async (req, res) => {
 };
 
 
-module.exports = { 
+module.exports = {
   createCliente,       // Para o cadastro manual
-  getAllClientes, 
-  getClienteById, 
-  updateCliente, 
-  deleteCliente, 
-  // uploadClientesCSV, // <--- REMOVIDO dos exports
+  getAllClientes,
+  getClienteById,
+  updateCliente,
+  deleteCliente,
+  uploadClientesCSV,
   deleteAllClientes,
   bulkImportClientes   // <--- ADICIONADO: Para a importação em massa
 };

--- a/src/api/clientes/cliente.service.js
+++ b/src/api/clientes/cliente.service.js
@@ -23,16 +23,11 @@ const create = async (data, userId) => {
 };
 
 /**
- * Retorna uma lista de clientes.
- * Se o usuário for 'admin', retorna todos.
- * Se for 'user', retorna apenas os que ele criou.
- * @param {object} user - O objeto do usuário logado (vindo do req.user).
+ * Retorna todos os clientes pertencentes ao usuário logado.
+ * @param {object} user - O objeto do usuário autenticado (vindo do req.user).
  */
 const findAll = async (user) => {
-    const query = {};
-    if (user.role !== 'admin') {
-        query.ownerId = new ObjectId(user.id); // Filtra os resultados pelo ID do dono
-    }
+    const query = { ownerId: new ObjectId(user.id) }; // Sempre filtra pelo ID do corretor
     return await getDb().collection(collection).find(query).toArray();
 };
 
@@ -46,8 +41,8 @@ const findById = async (id, user) => {
     const cliente = await getDb().collection(collection).findOne({ _id: new ObjectId(id) });
     if (!cliente) return null; // Se o cliente não existe, retorna nulo
 
-    // Se o usuário não for admin E o dono do cliente não for ele, lança um erro de permissão
-    if (user.role !== 'admin' && cliente.ownerId.toString() !== user.id) {
+    // Impede acesso a clientes de outros usuários
+    if (cliente.ownerId.toString() !== user.id) {
         throw new Error('Acesso negado a este recurso.');
     }
     return cliente;

--- a/src/api/clientes/cliente.test.js
+++ b/src/api/clientes/cliente.test.js
@@ -88,4 +88,68 @@ describe('API de Clientes (/api/clientes)', () => {
      expect(findResponse.body.nome).toBe(clienteData.nome);
      expect(findResponse.body._id).toBe(clienteId);
   });
+
+  it('deve retornar apenas os clientes pertencentes ao usuário autenticado', async () => {
+    // Cria um cliente para o primeiro usuário (token já definido no beforeAll)
+    const clienteUser1 = {
+      nome: 'Cliente User1',
+      email: 'cliente1@example.com',
+      status: 'Novo',
+      anexos: { customFields: [], timeline: [] },
+    };
+    await request(app)
+      .post('/api/clientes')
+      .set('Authorization', `Bearer ${token}`)
+      .send(clienteUser1);
+
+    // Cria um segundo usuário e autentica
+    const user2 = { name: 'User Two', email: 'user2@example.com', password: 'password123' };
+    await request(app).post('/api/auth/register').send(user2);
+    const login2 = await request(app).post('/api/auth/login').send({ email: user2.email, password: user2.password });
+    const token2 = login2.body.token;
+
+    // O primeiro usuário deve ver 1 cliente
+    const listUser1 = await request(app)
+      .get('/api/clientes')
+      .set('Authorization', `Bearer ${token}`);
+    expect(listUser1.statusCode).toBe(200);
+    expect(listUser1.body).toHaveLength(1);
+
+    // O segundo usuário não deve ver nenhum cliente
+    const listUser2 = await request(app)
+      .get('/api/clientes')
+      .set('Authorization', `Bearer ${token2}`);
+    expect(listUser2.statusCode).toBe(200);
+    expect(listUser2.body).toHaveLength(0);
+  });
+
+  it('admin também deve visualizar apenas os próprios clientes', async () => {
+    const { getDb } = require('../../config/database');
+
+    // Cria usuário admin
+    const admin = { name: 'Admin', email: 'admin@example.com', password: 'password123' };
+    await request(app).post('/api/auth/register').send(admin);
+    // Atualiza role para admin antes do login
+    await getDb().collection('users').updateOne({ email: admin.email.toLowerCase() }, { $set: { role: 'admin' } });
+    const loginAdmin = await request(app).post('/api/auth/login').send({ email: admin.email, password: admin.password });
+    const adminToken = loginAdmin.body.token;
+
+    // Cliente do admin
+    const clienteAdmin = { nome: 'Cliente Admin', email: 'cliente.admin@example.com', status: 'Novo', anexos: { customFields: [], timeline: [] } };
+    await request(app).post('/api/clientes').set('Authorization', `Bearer ${adminToken}`).send(clienteAdmin);
+
+    // Cria outro usuário com seu cliente
+    const user = { name: 'Outro', email: 'outro@example.com', password: 'password123' };
+    await request(app).post('/api/auth/register').send(user);
+    const loginUser = await request(app).post('/api/auth/login').send({ email: user.email, password: user.password });
+    const userToken = loginUser.body.token;
+    const clienteOutro = { nome: 'Cliente Outro', email: 'cliente.outro@example.com', status: 'Novo', anexos: { customFields: [], timeline: [] } };
+    await request(app).post('/api/clientes').set('Authorization', `Bearer ${userToken}`).send(clienteOutro);
+
+    // Admin deve ver apenas seu cliente
+    const listAdmin = await request(app).get('/api/clientes').set('Authorization', `Bearer ${adminToken}`);
+    expect(listAdmin.statusCode).toBe(200);
+    expect(listAdmin.body).toHaveLength(1);
+    expect(listAdmin.body[0].email).toBe(clienteAdmin.email);
+  });
 });


### PR DESCRIPTION
## Summary
- assegura que importações CSV associem clientes ao usuário autenticado
- adiciona teste garantindo que cada usuário veja apenas seus clientes
- restringe listagem e busca de clientes ao corretor autenticado independentemente da role

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac856dc66c8330a237f45678166061