### PR TITLE
Permite admin e manager consultar leads de qualquer corretor

### DIFF
--- a/src/api/clientes/cliente.routes.js
+++ b/src/api/clientes/cliente.routes.js
@@ -38,6 +38,20 @@ router.post('/', controller.createCliente);
 router.get('/', controller.getAllClientes);
 
 /**
+ * @route   GET /api/clientes/corretores
+ * @desc    Lista os corretores por nome
+ * @access  Privado (admin/manager)
+ */
+router.get('/corretores', controller.listCorretores);
+
+/**
+ * @route   GET /api/clientes/corretor/:corretorId
+ * @desc    Lista clientes de um corretor específico
+ * @access  Privado (admin/manager)
+ */
+router.get('/corretor/:corretorId', controller.getClientesByCorretor);
+
+/**
  * @route   GET /api/clientes/:id
  * @desc    Obtém um cliente específico pelo ID
  * @access  Privado (requer token)

--- a/src/api/users/user.service.js
+++ b/src/api/users/user.service.js
@@ -43,8 +43,13 @@ const findByEmail = async (email) => {
   return await getDb().collection(collection).findOne({ email: email.toLowerCase() });
 };
 
+const findAll = async () => {
+  return await getDb().collection(collection).find({}, { projection: { name: 1 } }).toArray();
+};
+
 // Exporta as funções para que outros serviços (como o auth.service) possam usá-las.
 module.exports = {
   create,
   findByEmail,
+  findAll,
 };


### PR DESCRIPTION
## Summary
- libera listagem geral de clientes para roles `admin` e `manager`
- adiciona endpoints para listar corretores e buscar leads de um corretor específico
- expande testes cobrindo acesso especial de administradores

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac856dc66c8330a237f45678166061