### PR TITLE
Restrict lead visibility and add global analytics endpoint

### DIFF
--- a/src/api/clientes/cliente.controller.js
+++ b/src/api/clientes/cliente.controller.js
@@ -19,6 +19,16 @@ const getAllClientes = async (req, res) => {
   } catch (error) { res.status(500).json({ message: error.message }); }
 };
 
+const getAllClientesAll = async (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'manager') {
+    return res.status(403).json({ message: 'Acesso negado' });
+  }
+  try {
+    const clientes = await clienteService.findAllGlobal();
+    res.status(200).json(clientes);
+  } catch (error) { res.status(500).json({ message: error.message }); }
+};
+
 const getClienteById = async (req, res) => {
   try {
     const cliente = await clienteService.findById(req.params.id, req.user);
@@ -132,6 +142,7 @@ const getClientesByCorretor = async (req, res) => {
 module.exports = {
   createCliente,       // Para o cadastro manual
   getAllClientes,
+  getAllClientesAll,
   getClienteById,
   updateCliente,
   deleteCliente,

--- a/src/api/clientes/cliente.routes.js
+++ b/src/api/clientes/cliente.routes.js
@@ -38,6 +38,13 @@ router.post('/', controller.createCliente);
 router.get('/', controller.getAllClientes);
 
 /**
+ * @route   GET /api/clientes/all
+ * @desc    Obtém todos os clientes (apenas admin/manager)
+ * @access  Privado (admin/manager)
+ */
+router.get('/all', controller.getAllClientesAll);
+
+/**
  * @route   GET /api/clientes/corretores
  * @desc    Lista os corretores por nome
  * @access  Privado (admin/manager)

--- a/src/api/clientes/cliente.service.js
+++ b/src/api/clientes/cliente.service.js
@@ -27,9 +27,14 @@ const create = async (data, userId) => {
  * @param {object} user - O objeto do usuário autenticado (vindo do req.user).
  */
 const findAll = async (user) => {
-    const isPrivileged = user.role === 'admin' || user.role === 'manager';
-    const query = isPrivileged ? {} : { ownerId: new ObjectId(user.id) };
-    return await getDb().collection(collection).find(query).toArray();
+    return await getDb()
+        .collection(collection)
+        .find({ ownerId: new ObjectId(user.id) })
+        .toArray();
+};
+
+const findAllGlobal = async () => {
+    return await getDb().collection(collection).find({}).toArray();
 };
 
 /**
@@ -146,6 +151,7 @@ const importFromCSV = (buffer, user) => {
 module.exports = {
     create,
     findAll,
+    findAllGlobal,
     findById,
     update,
     remove,

--- a/src/api/clientes/cliente.test.js
+++ b/src/api/clientes/cliente.test.js
@@ -120,7 +120,7 @@ describe('API de Clientes (/api/clientes)', () => {
     expect(listUser2.body).toHaveLength(0);
   });
 
-  it('admin deve visualizar todos os clientes e acessar endpoints especiais', async () => {
+  it('admin deve acessar todos os clientes via endpoint dedicado e manter funcionalidades especiais', async () => {
     const { getDb } = require('../../config/database');
 
     // Cria usuário admin e define role
@@ -142,10 +142,19 @@ describe('API de Clientes (/api/clientes)', () => {
     const clienteAdmin = { nome: 'Cliente Admin', email: 'cliente.admin@example.com', status: 'Novo', anexos: { customFields: [], timeline: [] } };
     await request(app).post('/api/clientes').set('Authorization', `Bearer ${adminToken}`).send(clienteAdmin);
 
-    // Admin deve ver ambos os clientes na listagem geral
+    // Admin deve ver apenas seus clientes no endpoint padrão
     const listAdmin = await request(app).get('/api/clientes').set('Authorization', `Bearer ${adminToken}`);
     expect(listAdmin.statusCode).toBe(200);
-    expect(listAdmin.body).toHaveLength(2);
+    expect(listAdmin.body).toHaveLength(1);
+
+    // Admin pode ver todos os clientes no endpoint /all
+    const listAdminAll = await request(app).get('/api/clientes/all').set('Authorization', `Bearer ${adminToken}`);
+    expect(listAdminAll.statusCode).toBe(200);
+    expect(listAdminAll.body).toHaveLength(2);
+
+    // Usuário comum não pode acessar o endpoint /all
+    const listUserAll = await request(app).get('/api/clientes/all').set('Authorization', `Bearer ${userToken}`);
+    expect(listUserAll.statusCode).toBe(403);
 
     // Admin pode listar corretores
     const corretores = await request(app).get('/api/clientes/corretores').set('Authorization', `Bearer ${adminToken}`);


### PR DESCRIPTION
## Summary
- Limit default client listing to authenticated user's leads
- Add admin-only endpoint to retrieve all clients for analysis
- Test coverage for new endpoint and access restrictions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac98077fd48330b298225880463af4