### PR TITLE
Implement corretor listing and client filtering

### DIFF
--- a/src/api/clientes/cliente.controller.js
+++ b/src/api/clientes/cliente.controller.js
@@ -1,7 +1,6 @@
 // /src/api/clientes/cliente.controller.js
 
 const clienteService = require('./cliente.service');
-const userService = require('../users/user.service');
 
 // --- FUNÇÃO PARA CADASTRO MANUAL (PERMANECE IGUAL) ---
 const createCliente = async (req, res) => {
@@ -14,7 +13,12 @@ const createCliente = async (req, res) => {
 // --- FUNÇÕES CRUD (PERMANECEM IGUAIS) ---
 const getAllClientes = async (req, res) => {
   try {
-    const clientes = await clienteService.findAll(req.user);
+    const { corretor } = req.query;
+    const isPrivileged = req.user.role === 'admin' || req.user.role === 'manager';
+    if (corretor && !isPrivileged) {
+      return res.status(403).json({ message: 'Acesso negado' });
+    }
+    const clientes = await clienteService.findAll(req.user, corretor);
     res.status(200).json(clientes);
   } catch (error) { res.status(500).json({ message: error.message }); }
 };
@@ -103,32 +107,6 @@ const bulkImportClientes = async (req, res) => {
   }
 };
 
-const listCorretores = async (req, res) => {
-  if (req.user.role !== 'admin' && req.user.role !== 'manager') {
-    return res.status(403).json({ message: 'Acesso negado' });
-  }
-  try {
-    const corretores = await userService.findAll();
-    const result = corretores.map(c => ({ id: c._id, name: c.name }));
-    res.status(200).json(result);
-  } catch (error) {
-    res.status(500).json({ message: error.message });
-  }
-};
-
-const getClientesByCorretor = async (req, res) => {
-  if (req.user.role !== 'admin' && req.user.role !== 'manager') {
-    return res.status(403).json({ message: 'Acesso negado' });
-  }
-  try {
-    const clientes = await clienteService.findByOwner(req.params.corretorId);
-    res.status(200).json(clientes);
-  } catch (error) {
-    res.status(500).json({ message: error.message });
-  }
-};
-
-
 module.exports = {
   createCliente,       // Para o cadastro manual
   getAllClientes,
@@ -138,6 +116,4 @@ module.exports = {
   uploadClientesCSV,
   deleteAllClientes,
   bulkImportClientes,  // <--- ADICIONADO: Para a importação em massa
-  listCorretores,
-  getClientesByCorretor
 };

--- a/src/api/clientes/cliente.routes.js
+++ b/src/api/clientes/cliente.routes.js
@@ -38,20 +38,6 @@ router.post('/', controller.createCliente);
 router.get('/', controller.getAllClientes);
 
 /**
- * @route   GET /api/clientes/corretores
- * @desc    Lista os corretores por nome
- * @access  Privado (admin/manager)
- */
-router.get('/corretores', controller.listCorretores);
-
-/**
- * @route   GET /api/clientes/corretor/:corretorId
- * @desc    Lista clientes de um corretor específico
- * @access  Privado (admin/manager)
- */
-router.get('/corretor/:corretorId', controller.getClientesByCorretor);
-
-/**
  * @route   GET /api/clientes/:id
  * @desc    Obtém um cliente específico pelo ID
  * @access  Privado (requer token)

--- a/src/api/clientes/cliente.service.js
+++ b/src/api/clientes/cliente.service.js
@@ -23,10 +23,17 @@ const create = async (data, userId) => {
 };
 
 /**
- * Retorna todos os clientes pertencentes ao usuário logado.
- * @param {object} user - O objeto do usuário autenticado (vindo do req.user).
+ * Retorna os clientes conforme o usuário e opcionalmente filtra por corretor.
+ * @param {object} user - O usuário autenticado.
+ * @param {string} [corretorName] - Nome do corretor para filtrar (apenas admin/manager).
  */
-const findAll = async (user) => {
+const findAll = async (user, corretorName) => {
+    if (corretorName) {
+        const corretor = await getDb().collection('users').findOne({ name: corretorName, role: 'user' });
+        if (!corretor) return [];
+        return await getDb().collection(collection).find({ ownerId: corretor._id }).toArray();
+    }
+
     const isPrivileged = user.role === 'admin' || user.role === 'manager';
     const query = isPrivileged ? {} : { ownerId: new ObjectId(user.id) };
     return await getDb().collection(collection).find(query).toArray();

--- a/src/api/corretores/corretor.controller.js
+++ b/src/api/corretores/corretor.controller.js
@@ -1,0 +1,16 @@
+const userService = require('../users/user.service');
+
+const listCorretores = async (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'manager') {
+    return res.status(403).json({ message: 'Acesso negado' });
+  }
+  try {
+    const corretores = await userService.findAll();
+    const nomes = corretores.map(c => c.name);
+    res.status(200).json(nomes);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+module.exports = { listCorretores };

--- a/src/api/corretores/corretor.routes.js
+++ b/src/api/corretores/corretor.routes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('./corretor.controller');
+const authMiddleware = require('../../middlewares/auth.middleware');
+
+router.use(authMiddleware);
+
+router.get('/', controller.listCorretores);
+
+module.exports = router;

--- a/src/api/users/user.service.js
+++ b/src/api/users/user.service.js
@@ -44,7 +44,14 @@ const findByEmail = async (email) => {
 };
 
 const findAll = async () => {
-  return await getDb().collection(collection).find({}, { projection: { name: 1 } }).toArray();
+  return await getDb()
+    .collection(collection)
+    .find({ role: 'user' }, { projection: { name: 1 } })
+    .toArray();
+};
+
+const findByName = async (name) => {
+  return await getDb().collection(collection).findOne({ name, role: 'user' });
 };
 
 // Exporta as funções para que outros serviços (como o auth.service) possam usá-las.
@@ -52,4 +59,5 @@ module.exports = {
   create,
   findByEmail,
   findAll,
+  findByName,
 };

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 
 const clienteRoutes = require('./api/clientes/cliente.routes');
 const authRoutes = require('./api/auth/auth.routes');
+const corretorRoutes = require('./api/corretores/corretor.routes');
 
 const app = express();
 
@@ -13,6 +14,7 @@ app.use(express.json());
 // Rotas da API
 app.use('/api/auth', authRoutes);
 app.use('/api/clientes', clienteRoutes);
+app.use('/api/corretores', corretorRoutes);
 
 app.get('/', (req, res) => {
   res.send('API do Sistema de Clientes está no ar!');

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -36,8 +36,13 @@ const getDb = () => {
 // --- ADICIONE ESTA FUNÇÃO ---
 const closeDatabase = async () => {
   if (client) {
-    await client.close();
-    db = null; // Limpa a variável db
+    try {
+      await client.close();
+    } catch (error) {
+      console.error('Erro ao fechar o MongoDB.', error);
+    } finally {
+      db = null;
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add `/api/corretores` endpoint for admin/manager listing of agents
- support `corretor` query param in `/api/clientes` for admin/manager filtering
- limit user listings to role `user` and improve database teardown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac99819c648330a70eb9ff86618c60